### PR TITLE
Fix nested subRows selected state not updating properly

### DIFF
--- a/src/plugin-hooks/useRowSelect.js
+++ b/src/plugin-hooks/useRowSelect.js
@@ -221,7 +221,7 @@ function reducer(state, action, previousState, instance) {
 function useInstance(instance) {
   const {
     data,
-    rows,
+    flatRows,
     getHooks,
     plugins,
     rowsById,
@@ -242,8 +242,7 @@ function useInstance(instance) {
 
   const selectedFlatRows = React.useMemo(() => {
     const selectedFlatRows = []
-
-    rows.forEach(row => {
+    flatRows.forEach(row => {
       const isSelected = selectSubRows
         ? getRowIsSelected(row, selectedRowIds, getSubRows)
         : !!selectedRowIds[row.id]
@@ -256,7 +255,7 @@ function useInstance(instance) {
     })
 
     return selectedFlatRows
-  }, [rows, selectSubRows, selectedRowIds, getSubRows])
+  }, [flatRows, selectSubRows, selectedRowIds, getSubRows])
 
   let isAllRowsSelected = Boolean(
     Object.keys(nonGroupedRowsById).length && Object.keys(selectedRowIds).length
@@ -348,10 +347,14 @@ function getRowIsSelected(row, selectedRowIds, getSubRows) {
       if (someSelected && !allChildrenSelected) {
         return
       }
+      const isRowSelected = getRowIsSelected(subRow, selectedRowIds, getSubRows)
 
-      if (getRowIsSelected(subRow, selectedRowIds, getSubRows)) {
+      if (isRowSelected !== false) {
         someSelected = true
       } else {
+        allChildrenSelected = false
+      }
+      if (isRowSelected === null) {
         allChildrenSelected = false
       }
     })


### PR DESCRIPTION
The logic for updating `isSelected` on a row was not being run for all nested subRows. This meant that checking/unchecking a subRow would not update the checked state for the checkbox even though the selectedRowsIds state was correct.

Also change the indeterminate state logic so that a parent row will be considered indeterminate if all direct subRows are also indeterminate (previously would consider indeterminate subRows as unchecked).