### PR TITLE
Pass subRows as childRows instead of leafRows

### DIFF
--- a/src/plugin-hooks/useGroupBy.js
+++ b/src/plugin-hooks/useGroupBy.js
@@ -295,7 +295,7 @@ function useInstance(instance) {
             ? flattenBy(groupedRows, 'leafRows')
             : groupedRows
 
-          const values = aggregateRowsToValues(leafRows, groupedRows, depth)
+          const values = aggregateRowsToValues(leafRows, subRows, depth)
 
           const row = {
             id,


### PR DESCRIPTION
The `childRows` being passed to the aggregate function was always the same as `leafRows`, so it was never useful. Not sure if this was a long-standing bug, but It seems like what we really want is `subRows` from the current grouped level. This `subRows` will be passed as `childRows` now, which allows us to access already aggregated data from leafRows resulting in much better performance.